### PR TITLE
feat: add `nameservers` option for custom name servers (equivalent of `--dns.resolvers` in Lego)

### DIFF
--- a/certbot_dns_multi/_internal/dns_multi.py
+++ b/certbot_dns_multi/_internal/dns_multi.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from time import sleep
-from typing import Any, Callable, List, Mapping
+from typing import Any, Callable, List, Mapping, Optional
 
 from acme import challenges
 from certbot import achallenges, errors
@@ -143,7 +143,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
 class LegoClient:
     @staticmethod
-    def configure(provider: str, credentials: Mapping[str, str]):
+    def configure(provider: str, credentials: Mapping[str, str], nameservers: Optional[List[str]] = None):
         LegoClient._raise_for_response(
             cmd(
                 json.dumps(
@@ -151,6 +151,7 @@ class LegoClient:
                         "action": "configure",
                         "provider": provider,
                         "credentials": credentials,
+                        "nameservers": nameservers,
                     }
                 )
             )


### PR DESCRIPTION
This PR adds an option `--dns-multi-nameservers` that accepts a comma-separated list of recursive name servers to be used for ACME. This is useful for split DNS, where the system DNS resolution may diverge with a public DNS.

Alternatively we can add an option to enforce the use public DNS (most commonly DoT/DoH), but that is less flexible and we need to determine which public DNS to trust.